### PR TITLE
If you try to return a HttpResponse from a view decorated with pjaxtend, it breaks.

### DIFF
--- a/djpjax.py
+++ b/djpjax.py
@@ -29,10 +29,13 @@ def pjaxtend(parent='base.html', pjax_parent='pjax.html', context_var='parent'):
             # if not hasattr(resp, "is_rendered"):
             #     warnings.warn("@pjax used with non-template-response view")
             #     return resp
-            if request.META.get('HTTP_X_PJAX', False):
-                resp.context_data[context_var] = pjax_parent
-            elif parent:
-                resp.context_data[context_var] = parent
+            try:
+                if request.META.get('HTTP_X_PJAX', False):
+                    resp.context_data[context_var] = pjax_parent
+                elif parent:
+                    resp.context_data[context_var] = parent
+            except AttributeError:
+                pass
             return resp
         return _view
     return pjaxtend_decorator


### PR DESCRIPTION
This fixes that.
