### PR TITLE
Fix for pjaxtend with HttpResponse w/ test

### DIFF
--- a/djpjax.py
+++ b/djpjax.py
@@ -29,10 +29,13 @@ def pjaxtend(parent='base.html', pjax_parent='pjax.html', context_var='parent'):
             # if not hasattr(resp, "is_rendered"):
             #     warnings.warn("@pjax used with non-template-response view")
             #     return resp
-            if request.META.get('HTTP_X_PJAX', False):
-                resp.context_data[context_var] = pjax_parent
-            elif parent:
-                resp.context_data[context_var] = parent
+            try:
+                if request.META.get('HTTP_X_PJAX', False):
+                    resp.context_data[context_var] = pjax_parent
+                elif parent:
+                    resp.context_data[context_var] = parent
+            except AttributeError:
+                pass
             return resp
         return _view
     return pjaxtend_decorator

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,7 @@ from django.conf import settings; settings.configure()
 
 import djpjax
 from django.template.response import TemplateResponse
+from django.http import HttpResponse
 from django.test.client import RequestFactory
 from django.views.generic import View
 
@@ -89,6 +90,10 @@ def test_pjaxtend_custom_context():
     resp = view_custom_context_pjaxtend(pjax_request)
     assert resp.template_name == "template.html"
     assert resp.context_data['my_parent'] == "parent-pjax.html"
+    
+def test_handle_httpresponse():
+    resp = view_httpresponse(regular_request)
+    assert resp.status_code == 200
 
 # The test "views" themselves.
 
@@ -123,6 +128,10 @@ def view_custom_parent_pjaxtend(request):
 @djpjax.pjaxtend('parent.html', 'parent-pjax.html', 'my_parent')
 def view_custom_context_pjaxtend(request):
     return TemplateResponse(request, "template.html", {})
+
+@djpjax.pjaxtend()
+def view_httpresponse(request):
+    return HttpResponse("This is a test.")
 
 class NoPJAXTemplateVew(djpjax.PJAXResponseMixin, View):
     template_name = 'template.html'


### PR DESCRIPTION
I added radiosilence's fix (https://github.com/jacobian/django-pjax/pull/9) along with a test that returns a HttpResponse while decorated with pjaxtend.

The test failed prior to the change, and passes after the try/except.
