### PR TITLE
Fix pjaxtend example by adding parens

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ If the content in your ``template-pjax.html`` file is very similar to your
 
     from djpjax import pjaxtend
     
-    @pjaxtend
+    @pjaxtend()
     def my_view(request):
         return TemplateResponse(request, "template.html", {'my': 'context'})
 


### PR DESCRIPTION
As documented, @pjaxtend wouldn't work as it triggered a WSGIError. Adding the parens, for `@pjaxtend()`, works perfectly.
